### PR TITLE
Adding horizontal scroll lazyload and offset for desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The lazy loaded component is unmounted and replaced by the placeholder when it i
 
 ### forceCheck
 
-This is avaible to manually trigger checking for elements in viewport. Helpful when LazyLoad compoents enter the viewport without resize or scroll events, e.g. when the components' container was hidden then become visible.
+This is avaible to manually trigger checking for elements in viewport. Helpful when LazyLoad components enter the viewport without resize or scroll events, e.g. when the components' container was hidden then become visible.
 
 Import `forceCheck`:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ class MyComponent extends React.Component {
 }
 ```
 
-You should aware that your component will only be mounted when it's visible in viewport, before that a placeholder will be rendered. 
+You should aware that your component will only be mounted when it's visible in viewport, before that a placeholder will be rendered.
 
 So you can safely send request in your component's `componentDidMount` without worring about performance loss or add some pretty entering effect, see this [demo](https://jasonslyvia.github.io/react-lazyload/examples/#/fadein) for more detail.
 
@@ -150,6 +150,12 @@ Specify a placeholder for your lazy loaded component.
 [demo](https://jasonslyvia.github.io/react-lazyload/examples/#/placeholder)
 
 **If you provide your own placeholder, do remember add appropriate `height` or `minHeight` to your placeholder element for better lazyload performance.**
+
+### unmountIfInvisible
+
+Type: Bool Default: false
+
+The lazy loaded component is unmounted and replaced by the placeholder when it is no longer visible in the viewport.
 
 ## Utility
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lazyload your Components, Images or anything matters the performance.
 
-[Online Demo](//jasonslyvia.github.io/react-lazyload/examples/)
+[Demo](//jasonslyvia.github.io/react-lazyload/examples/)
 
 ## Why it's better
 

--- a/README.md
+++ b/README.md
@@ -161,22 +161,18 @@ The lazy loaded component is unmounted and replaced by the placeholder when it i
 
 ### forceCheck
 
-This is avaible to manually trigger checking for elements in viewport. Helpful when LazyLoad components enter the viewport without resize or scroll events, e.g. when the components' container was hidden then become visible.
+It is available to manually trigger checking for elements in viewport. Helpful when LazyLoad components enter the viewport without resize or scroll events, e.g. when the components' container was hidden then become visible.
 
 Import `forceCheck`:
 
 ```javascript
-
-import {forceCheck} from 'react-lazyload';
-
+import { forceCheck } from 'react-lazyload';
 ```
 
 Then call the function:
 
 ```javascript
-
 forceCheck();
-
 ```
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,6 +133,9 @@ var checkVisible = function checkVisible(component) {
     }
   } else if (!(component.props.once && component.visible)) {
     component.visible = false;
+    if (component.props.unmountIfInvisible) {
+      component.forceUpdate();
+    }
   }
 };
 
@@ -298,7 +301,8 @@ LazyLoad.propTypes = {
   children: _react.PropTypes.node,
   throttle: _react.PropTypes.oneOfType([_react.PropTypes.number, _react.PropTypes.bool]),
   debounce: _react.PropTypes.oneOfType([_react.PropTypes.number, _react.PropTypes.bool]),
-  placeholder: _react.PropTypes.node
+  placeholder: _react.PropTypes.node,
+  unmountIfInvisible: _react.PropTypes.bool
 };
 
 LazyLoad.defaultProps = {
@@ -306,7 +310,8 @@ LazyLoad.defaultProps = {
   offset: 0,
   overflow: false,
   resize: false,
-  scroll: true
+  scroll: true,
+  unmountIfInvisible: false
 };
 
 var lazyload = exports.lazyload = _decorator2.default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-lazyload",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Lazyload your Component, Image or anything matters the performance.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,9 @@ const checkVisible = function checkVisible(component) {
     }
   } else if (!(component.props.once && component.visible)) {
     component.visible = false;
+    if (component.props.unmountIfInvisible) {
+      component.forceUpdate();
+    }
   }
 };
 
@@ -255,7 +258,8 @@ LazyLoad.propTypes = {
   children: PropTypes.node,
   throttle: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   debounce: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
-  placeholder: PropTypes.node
+  placeholder: PropTypes.node,
+  unmountIfInvisible: PropTypes.bool
 };
 
 LazyLoad.defaultProps = {
@@ -263,7 +267,8 @@ LazyLoad.defaultProps = {
   offset: 0,
   overflow: false,
   resize: false,
-  scroll: true
+  scroll: true,
+  unmountIfInvisible: false
 };
 
 import decorator from './decorator';


### PR DESCRIPTION
A parent element with `.lazyload-x-axis` will trigger the horizontal lazyload with an offset.
A parent element with `.lazyload-handheld` will make the offset to be not triggered.