### PR TITLE
Lazy load images

### DIFF
--- a/examples/pages/image.js
+++ b/examples/pages/image.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Lazyload from '../../src/';
 import Operation from '../components/Operation';
+import PlaceholderComponent from '../components/Placeholder';
 
 export default class Image extends Component {
   render() {
@@ -8,28 +9,28 @@ export default class Image extends Component {
       <div className="wrapper">
         <Operation type="image" noExtra />
         <div className="widget-list image-container">
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww3.sinaimg.cn/mw690/62aad664jw1f2nxvya0u2j20u01hc16p.jpg" />
           </Lazyload>
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxvyo52qj20u01hcqeq.jpg" />
           </Lazyload>
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww2.sinaimg.cn/mw690/62aad664jw1f2nxvz2cj6j20u01hck1o.jpg" />
           </Lazyload>
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxvzfjv6j20u01hc496.jpg" />
           </Lazyload>
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxw0e1mlj20u01hcgvs.jpg" />
           </Lazyload>
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww4.sinaimg.cn/mw690/62aad664jw1f2nxw0p95dj20u01hc7d8.jpg" />
           </Lazyload>
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww2.sinaimg.cn/mw690/62aad664jw1f2nxw134xqj20u01hcqjg.jpg" />
           </Lazyload>
-          <Lazyload throttle={200} height={300}>
+          <Lazyload throttle={200} height={300} placeholder={<PlaceholderComponent />}>
             <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxw1kcykj20u01hcn9p.jpg" />
           </Lazyload>
         </div>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -134,7 +134,8 @@ const checkVisible = function checkVisible(component) {
   if (visible) {
     // Avoid extra render if previously is visible
     if (!component.visible) {
-      if (component.props.children.type === "img") {
+      const type = component.props.children.type;
+      if (type === 'img' || (type.target && type.target === 'img')) {
         const source = component.props.children.props.src;
         if (!source) {
           return;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -116,7 +116,13 @@ const checkVisible = function checkVisible(component) {
   if (!node) {
     return;
   }
-
+  const setVisible = () => {
+    if (component.props.once) {
+      pending.push(component);
+    }
+    component.visible = true;
+    component.forceUpdate();
+  };
   const parent = scrollParent(node);
   const isOverflow = component.props.overflow &&
                      parent !== node.ownerDocument &&
@@ -128,12 +134,19 @@ const checkVisible = function checkVisible(component) {
   if (visible) {
     // Avoid extra render if previously is visible
     if (!component.visible) {
-      if (component.props.once) {
-        pending.push(component);
+      if (component.props.children.type === "img") {
+        const source = component.props.children.props.src;
+        if (!source) {
+          return;
+        }
+        const image = new Image();
+        image.src = source;
+        image.onload = () => {
+          setVisible();
+        };
+      } else {
+        setVisible();
       }
-
-      component.visible = true;
-      component.forceUpdate();
     }
   } else if (!(component.props.once && component.visible)) {
     component.visible = false;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -144,6 +144,9 @@ const checkVisible = function checkVisible(component) {
         image.onload = () => {
           setVisible();
         };
+        image.onerror = () => {
+          setVisible();
+        };
       } else {
         setVisible();
       }


### PR DESCRIPTION
Before if an image became visible in the viewport the placeholder would be replaced by the image even if the image was not loaded (slow 3g for example), now the placeholder is shown until the image is actually loaded from the network.