### PR TITLE
Add `render` prop as part of API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,5 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -269,11 +269,14 @@ class LazyLoad extends Component {
   }
 
   render() {
-    return this.visible ?
-           this.props.children :
-             this.props.placeholder ?
-                this.props.placeholder :
-                <div style={{ height: this.props.height }} className="lazyload-placeholder" />;
+    const { children, placeholder, render, height } = this.props;
+    if (!this.visible) {
+      return placeholder || <div style={{ height }} className="lazyload-placeholder" />;
+    }
+    if (render) {
+      return render();
+    }
+    return children;
   }
 }
 
@@ -285,6 +288,7 @@ LazyLoad.propTypes = {
   resize: PropTypes.bool,
   scroll: PropTypes.bool,
   children: PropTypes.node,
+  render: PropTypes.func,
   throttle: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   debounce: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   placeholder: PropTypes.node,

--- a/test/Test.component.js
+++ b/test/Test.component.js
@@ -4,7 +4,7 @@ export default class Test extends React.Component {
   constructor() {
     super();
     this.state = {
-      times: 1
+      times: 1,
     };
   }
 
@@ -12,6 +12,13 @@ export default class Test extends React.Component {
     this.setState({
       times: this.state.times + 1
     });
+  }
+
+  componentDidMount() {
+    const { mounted } = this.props;
+    if (mounted) {
+      mounted();
+    }
   }
 
   render() {

--- a/test/specs/lazyload.spec.js
+++ b/test/specs/lazyload.spec.js
@@ -1,8 +1,9 @@
 /* eslint no-unused-expressions: 0 */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import LazyLoad, { lazyload } from '../../src/index';
 import spies from 'chai-spies';
+
+import LazyLoad, { lazyload } from '../../src/index';
 import Test from '../Test.component';
 import * as event from '../../src/utils/event';
 
@@ -46,6 +47,49 @@ describe('LazyLoad', () => {
       expect(document.querySelector('.something')).to.exist;
       expect(document.querySelector('.lazyload-placeholder')).to.exist;
       expect(document.querySelector('.treasure')).to.not.exist;
+    });
+
+    it('still mounts children when children not visible', () => {
+      const spy = chai.spy();
+      ReactDOM.render(
+        <div>
+          <LazyLoad height={9999}><Test height={9999} className="something">123</Test></LazyLoad>
+          <LazyLoad height={9999}>
+            <Test
+              className="something"
+              height={9999}
+              mounted={spy}
+            >
+              123
+            </Test>
+          </LazyLoad>
+        </div>
+      , div);
+
+      expect(spy).to.have.been.called;
+    });
+
+    it('does not mount rendered components when not visible', () => {
+      const spy = chai.spy();
+      ReactDOM.render(
+        <div>
+          <LazyLoad height={9999}><Test height={9999} className="something">123</Test></LazyLoad>
+          <LazyLoad
+            height={9999}
+            render={() => (
+              <Test
+                className="something"
+                height={9999}
+                mounted={spy}
+              >
+                123
+              </Test>
+            )}
+          />
+        </div>
+      , div);
+
+      expect(spy).to.not.have.been.called;
     });
 
     it('should NOT update when invisble', (done) => {
@@ -162,6 +206,45 @@ describe('LazyLoad', () => {
 
       setTimeout(() => {
         expect(document.querySelector('.lazyload-placeholder')).to.not.exist;
+        expect(document.querySelector('.treasure')).to.exist;
+        done();
+      }, 1000);
+    });
+
+    it.skip('should use render prop when scrolled visible', (done) => {
+      const windowHeight = window.innerHeight + 20;
+      ReactDOM.render(
+        <div>
+          <LazyLoad height={windowHeight} render={() => <Test className="something" height={windowHeight}>123</Test>} />
+          <LazyLoad height={windowHeight} render={() => <Test className="treasure" height={windowHeight}>123</Test>} />
+        </div>
+      , div);
+
+      expect(document.querySelector('.lazyload-placeholder')).to.exist;
+      window.scrollTo(0, 50);
+
+      setTimeout(() => {
+        expect(document.querySelector('.lazyload-placeholder')).to.not.exist;
+        expect(document.querySelector('.treasure')).to.exist;
+        done();
+      }, 1000);
+    });
+
+    it.skip('should use render prop when both children and render are provided and scrolled visible', (done) => {
+      const windowHeight = window.innerHeight + 20;
+      ReactDOM.render(
+        <div>
+          <LazyLoad height={windowHeight}><Test className="something" height={windowHeight}>123</Test></LazyLoad>
+          <LazyLoad height={windowHeight} render={() => <Test className="treasure" height={windowHeight}>123</Test>}><Test className="junk" height={windowHeight}>123</Test></LazyLoad>
+        </div>
+      , div);
+
+      expect(document.querySelector('.lazyload-placeholder')).to.exist;
+      window.scrollTo(0, 50);
+
+      setTimeout(() => {
+        expect(document.querySelector('.lazyload-placeholder')).to.not.exist;
+        expect(document.querySelector('.junk')).to.not.exist;
         expect(document.querySelector('.treasure')).to.exist;
         done();
       }, 1000);


### PR DESCRIPTION
Fixes #222 

## Motivation
See #222. When you add a component to the render tree, even if the parent JSX element chooses not to render the child, the child is still mounted, which in some cases may be less than ideal. Using a `render` prop that only executes when the conditions are met is one way to sidestep this.

Another approach would be to use a children function that calls with the lazyload state of the component, which would let you do something like this:
```javascript
<LazyLoad>
  {matches => (
    matches
    ? <Foo />
    : <Bar />
  )}
</LazyLoad>
```
Which would give the same benefits as a `render` prop while simultaneously giving you more control over how the children are rendered. This could be left for future work, though. If you're interested, [`react-media`](https://github.com/ReactTraining/react-media/) is a component that works this way.

## Changes
* Add indent rules to .editorconfig
* Add a means to spy on whether the Test component has mounted
* Write tests that get at the ideas I'm referencing in #222 
* Write a `render` prop API into the lazyload component