### PR TITLE
Add feature to have horizontal lazy-load

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# LOOKING FOR MAINTAINERS
+
+Due to personal reason I can't put much focus on this project, so if you're interested in maintaining `react-lazyload`, feel free to open an issue to get in touch!
+
+----
+
 # react-lazyload [![Build Status](https://travis-ci.org/jasonslyvia/react-lazyload.svg)](https://travis-ci.org/jasonslyvia/react-lazyload) [![npm version](https://badge.fury.io/js/react-lazyload.svg)](http://badge.fury.io/js/react-lazyload) [![Coverage Status](https://coveralls.io/repos/github/jasonslyvia/react-lazyload/badge.svg?branch=master)](https://coveralls.io/github/jasonslyvia/react-lazyload?branch=master) [![npm downloads](https://img.shields.io/npm/dm/react-lazyload.svg)](https://www.npmjs.com/package/react-lazyload)
 
 Lazyload your Components, Images or anything matters the performance.

--- a/lib/index.js
+++ b/lib/index.js
@@ -294,7 +294,7 @@ var LazyLoad = function (_Component) {
         listeners.splice(index, 1);
       }
 
-      if (listeners.length === 0 && window) {
+      if (listeners.length === 0 && typeof window !== 'undefined') {
         (0, _event.off)(window, 'resize', finalLazyLoadHandler, passiveEvent);
         (0, _event.off)(window, 'scroll', finalLazyLoadHandler, passiveEvent);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -219,32 +219,9 @@ var LazyLoad = function (_Component) {
   _createClass(LazyLoad, [{
     key: 'componentDidMount',
     value: function componentDidMount() {
-      if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
-        if (_react2.default.Children.count(this.props.children) > 1) {
-          console.warn('[react-lazyload] Only one child is allowed to be passed to `LazyLoad`.');
-        }
-
-        if (this.props.wheel) {
-          // eslint-disable-line
-          console.warn('[react-lazyload] Props `wheel` is not supported anymore, try set `overflow` for lazy loading in overflow containers.');
-        }
-
-        // Warn the user if placeholder and height is not specified and the rendered height is 0
-        if (!this.props.placeholder && this.props.height === undefined && _reactDom2.default.findDOMNode(this).offsetHeight === 0) {
-          console.warn('[react-lazyload] Please add `height` props to <LazyLoad> for better performance.');
-        }
-      }
-
       // It's unlikely to change delay type on the fly, this is mainly
       // designed for tests
-      var needResetFinalLazyLoadHandler = false;
-      if (this.props.debounce !== undefined && delayType === 'throttle') {
-        console.warn('[react-lazyload] Previous delay function is `throttle`, now switching to `debounce`, try setting them unanimously');
-        needResetFinalLazyLoadHandler = true;
-      } else if (delayType === 'debounce' && this.props.debounce === undefined) {
-        console.warn('[react-lazyload] Previous delay function is `debounce`, now switching to `throttle`, try setting them unanimously');
-        needResetFinalLazyLoadHandler = true;
-      }
+      var needResetFinalLazyLoadHandler = this.props.debounce !== undefined && delayType === 'throttle' || delayType === 'debounce' && this.props.debounce === undefined;
 
       if (needResetFinalLazyLoadHandler) {
         (0, _event.off)(window, 'scroll', finalLazyLoadHandler, passiveEvent);
@@ -317,7 +294,7 @@ var LazyLoad = function (_Component) {
         listeners.splice(index, 1);
       }
 
-      if (listeners.length === 0) {
+      if (listeners.length === 0 && window) {
         (0, _event.off)(window, 'resize', finalLazyLoadHandler, passiveEvent);
         (0, _event.off)(window, 'scroll', finalLazyLoadHandler, passiveEvent);
       }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -252,7 +252,7 @@ class LazyLoad extends Component {
       listeners.splice(index, 1);
     }
 
-    if (listeners.length === 0) {
+    if (listeners.length === 0 && window) {
       off(window, 'resize', finalLazyLoadHandler, passiveEvent);
       off(window, 'scroll', finalLazyLoadHandler, passiveEvent);
     }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -252,7 +252,7 @@ class LazyLoad extends Component {
       listeners.splice(index, 1);
     }
 
-    if (listeners.length === 0 && window) {
+    if (listeners.length === 0 && typeof window !== 'undefined') {
       off(window, 'resize', finalLazyLoadHandler, passiveEvent);
       off(window, 'scroll', finalLazyLoadHandler, passiveEvent);
     }


### PR DESCRIPTION
This PR will add a way to horizontally lazy-load items. This is useful for instance, when working with a carousel.

Also, it fixes an error when using SSR frameworks like Next or react-tree-walker. They offer a way to unmount components on server, which causes react-lazyload to throw a lot of error since window is used in the componentWillUnmount.