### PR TITLE
feat(Lazyload): adding manual control over rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ If you provide a number, that will be how many `ms` to wait; if you provide `tru
 **DEPRECATED NOTICE**
 This props is not supported anymore, try set `overflow` for lazy loading in overflow containers.
 
+### preventLoading
+
+Type: Bool Default: false
+
+If set to true your component will not be mounted even if it is visible in the viewport. Use it when you want to have a manual control over when your component is lazyloaded. 
+
+One use case for that would be in galleries, for instance, you may want the visible item to be loaded when in viewport but the not yet visible items to only be loaded when the user interacts with the gallery.
+
+[demo](https://twobin.github.io/react-lazyload/examples/#/preventLoading)
+
 ## Utility
 
 ### forceCheck

--- a/examples/app.js
+++ b/examples/app.js
@@ -10,6 +10,7 @@ import Image from './pages/image';
 import Debounce from './pages/debounce';
 import Placeholder from './pages/placeholder';
 import FadeIn from './pages/fadein';
+import PreventLoading from './pages/preventLoading';
 
 const Home = () => (
   <ul className="nav">
@@ -21,6 +22,7 @@ const Home = () => (
     <li><Link to="/debounce">using <code>debounce</code></Link></li>
     <li><Link to="/placeholder">custom placeholder</Link></li>
     <li><Link to="/fadein">cool <code>fadeIn</code> effect</Link></li>
+    <li><Link to="/preventLoading">using <code>preventLoading</code></Link></li>
   </ul>
 );
 
@@ -35,6 +37,7 @@ const routes = (
     <Route path="/debounce" component={Debounce} />
     <Route path="/placeholder" component={Placeholder} />
     <Route path="/fadein" component={FadeIn} />
+    <Route path="/preventLoading" component={PreventLoading} />
   </Router>
 );
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -176,6 +176,39 @@ https://github.com/yahoo/pure/blob/master/LICENSE.md
     opacity: 1;
     transition: opacity .5s ease-in;
   }
+
+  .gallery {
+    height: 1231px;
+    width: 690px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .gallery-items-list {
+    list-style: none;
+    white-space: nowrap;
+    display: flex;
+    transition: transform 200ms ease-in-out;
+  }
+
+  .gallery-item {
+    display: inline-flex;
+  }
+
+  .gallery-control {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .galley-control.left {
+    left: 0;
+  }
+
+  .gallery-control.right {
+    right: 0;
+  }
+
   </style>
 </head>
 <body>

--- a/examples/pages/preventLoading.js
+++ b/examples/pages/preventLoading.js
@@ -1,0 +1,83 @@
+import React, { Component } from 'react';
+import Operation from '../components/Operation';
+import Lazyload from '../../src/';
+import PlaceholderComponent from '../components/Placeholder';
+
+export default class PreventLoading extends Component {
+  constructor() {
+    super();
+    this.state = {
+      currentItem: 0,
+    };
+
+    this.forward = () => {
+      if (this.state.currentItem < 7) {
+        this.setState({
+          currentItem: this.state.currentItem + 1,
+        });
+      }
+    };
+
+    this.back = () => {
+      if (this.state.currentItem > 0) {
+        this.setState({
+          currentItem: this.state.currentItem - 1,
+        });
+      }
+    };
+  }
+
+  render() {
+    return <div className="wrapper">
+      <Operation type="preventLoading" noExtra />
+      <div className="widget-list">
+        <div className="gallery">
+          <ul className="gallery-items-list" style={{ transform: `translateX(-${this.state.currentItem * 690}px)` }}>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 0}>
+                <img src="http://ww3.sinaimg.cn/mw690/62aad664jw1f2nxvya0u2j20u01hc16p.jpg" />
+              </Lazyload>
+            </li>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 1}>
+                <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxvyo52qj20u01hcqeq.jpg" />
+              </Lazyload>
+            </li>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 2}>
+                <img src="http://ww2.sinaimg.cn/mw690/62aad664jw1f2nxvz2cj6j20u01hck1o.jpg" />
+              </Lazyload>
+            </li>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 3}>
+                <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxvzfjv6j20u01hc496.jpg" />
+              </Lazyload>
+            </li>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 4}>
+                <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxw0e1mlj20u01hcgvs.jpg" />
+              </Lazyload>
+            </li>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 5}>
+                <img src="http://ww4.sinaimg.cn/mw690/62aad664jw1f2nxw0p95dj20u01hc7d8.jpg" />
+              </Lazyload>
+            </li>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 6}>
+                <img src="http://ww2.sinaimg.cn/mw690/62aad664jw1f2nxw134xqj20u01hcqjg.jpg" />
+              </Lazyload>
+            </li>
+            <li className="gallery-item">
+              <Lazyload height={1231} placeholder={<PlaceholderComponent />} offset={9999} preventLoading={this.state.currentItem < 7}>
+                <img src="http://ww1.sinaimg.cn/mw690/62aad664jw1f2nxw1kcykj20u01hcn9p.jpg" />
+              </Lazyload>
+            </li>
+          </ul>
+          <button className="gallery-control left" onClick={this.back}>{"<<"}</button>
+          <button className="gallery-control right" onClick={this.forward}>{">>"}</button>
+        </div>
+      </div>
+    </div>;
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,10 +33,6 @@ var _throttle = require('./utils/throttle');
 
 var _throttle2 = _interopRequireDefault(_throttle);
 
-var _decorator = require('./decorator');
-
-var _decorator2 = _interopRequireDefault(_decorator);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -81,23 +77,18 @@ var checkOverflowVisible = function checkOverflowVisible(component, parent) {
   var parentHeight = void 0;
   var parentWidth = void 0;
 
-  var parentWidth = void 0;
-  var parentLeft = void 0;
-
   try {
     var _parent$getBoundingCl = parent.getBoundingClientRect();
 
     parentTop = _parent$getBoundingCl.top;
     parentLeft = _parent$getBoundingCl.left;
     parentHeight = _parent$getBoundingCl.height;
-
     parentWidth = _parent$getBoundingCl.width;
-    parentLeft = _parent$getBoundingCl.left;
-
   } catch (e) {
     parentTop = defaultBoundingClientRect.top;
     parentLeft = defaultBoundingClientRect.left;
     parentHeight = defaultBoundingClientRect.height;
+    parentWidth = defaultBoundingClientRect.width;
   }
 
   var windowInnerHeight = window.innerHeight || document.documentElement.clientHeight;
@@ -109,16 +100,10 @@ var checkOverflowVisible = function checkOverflowVisible(component, parent) {
   var intersectionHeight = Math.min(windowInnerHeight, parentTop + parentHeight) - intersectionTop; // height
   var intersectionWidth = Math.min(windowInnerWidth, parentLeft + parentWidth) - intersectionLeft; // width
 
-  var intersectionLeft = Math.max(parentLeft, 0)
-  var intersectionWidth = Math.min(windowInnerWidth, parentLeft + parentWidth) - intersectionLeft;
-  
   // check whether the element is visible in the intersection
   var top = void 0;
   var left = void 0;
   var height = void 0;
-  var width = void 0;
-
-  var left = void 0;
   var width = void 0;
 
   try {
@@ -127,13 +112,12 @@ var checkOverflowVisible = function checkOverflowVisible(component, parent) {
     top = _node$getBoundingClie.top;
     left = _node$getBoundingClie.left;
     height = _node$getBoundingClie.height;
-
     width = _node$getBoundingClie.width;
-    left = _node$getBoundingClie.left;
   } catch (e) {
     top = defaultBoundingClientRect.top;
     left = defaultBoundingClientRect.left;
     height = defaultBoundingClientRect.height;
+    width = defaultBoundingClientRect.width;
   }
 
   var offsetTop = top - intersectionTop; // element's top relative to intersection
@@ -158,32 +142,21 @@ var checkNormalVisible = function checkNormalVisible(component) {
   var top = void 0;
   var elementHeight = void 0;
 
-  var left = void 0;
-  var elementWidth = void 0;
-
   try {
     var _node$getBoundingClie2 = node.getBoundingClientRect();
 
     top = _node$getBoundingClie2.top;
     elementHeight = _node$getBoundingClie2.height;
-
-    left = _node$getBoundingClie2.left;
-    elementWidth = _node$getBoundingClie2.width;
-
   } catch (e) {
     top = defaultBoundingClientRect.top;
     elementHeight = defaultBoundingClientRect.height;
-
-    left = defaultBoundingClientRect.left;
-    elementWidth = defaultBoundingClientRect.width;
   }
 
   var windowInnerHeight = window.innerHeight || document.documentElement.clientHeight;
-  var windowInnerWidth = window.innerWidth || document.documentElement.clientWidth;
 
   var offsets = Array.isArray(component.props.offset) ? component.props.offset : [component.props.offset, component.props.offset]; // Be compatible with previous API
-  
-  return (top - offsets[0] <= windowInnerHeight && top + elementHeight + offsets[1] >= 0) && (left - offsets[0] <= windowInnerWidth && left + elementWidth + offsets[1] >= 0);
+
+  return top - offsets[0] <= windowInnerHeight && top + elementHeight + offsets[1] >= 0;
 };
 
 /**
@@ -197,13 +170,13 @@ var checkVisible = function checkVisible(component) {
   if (!(node instanceof HTMLElement)) {
     return;
   }
-  
+
   var parent = (0, _scrollParent2.default)(node);
   var isOverflow = component.props.overflow && parent !== node.ownerDocument && parent !== document && parent !== document.documentElement;
   var visible = isOverflow ? checkOverflowVisible(component, parent) : checkNormalVisible(component);
   if (visible) {
     // Avoid extra render if previously is visible
-    if (!component.visible) {
+    if (!component.visible && !component.preventLoading) {
       if (component.props.once) {
         pending.push(component);
       }
@@ -345,7 +318,7 @@ var LazyLoad = function (_Component) {
         listeners.splice(index, 1);
       }
 
-      if (listeners.length === 0) {
+      if (listeners.length === 0 && typeof window !== 'undefined') {
         (0, _event.off)(window, 'resize', finalLazyLoadHandler, passiveEvent);
         (0, _event.off)(window, 'scroll', finalLazyLoadHandler, passiveEvent);
       }
@@ -372,7 +345,8 @@ LazyLoad.propTypes = {
   debounce: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.bool]),
   placeholder: _propTypes2.default.node,
   scrollContainer: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.object]),
-  unmountIfInvisible: _propTypes2.default.bool
+  unmountIfInvisible: _propTypes2.default.bool,
+  preventLoading: _propTypes2.default.bool
 };
 
 LazyLoad.defaultProps = {
@@ -381,9 +355,45 @@ LazyLoad.defaultProps = {
   overflow: false,
   resize: false,
   scroll: true,
-  unmountIfInvisible: false
+  unmountIfInvisible: false,
+  preventLoading: false
 };
 
-var lazyload = exports.lazyload = _decorator2.default;
+var getDisplayName = function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+};
+
+var decorator = function decorator() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  return function lazyload(WrappedComponent) {
+    return function (_Component2) {
+      _inherits(LazyLoadDecorated, _Component2);
+
+      function LazyLoadDecorated() {
+        _classCallCheck(this, LazyLoadDecorated);
+
+        var _this2 = _possibleConstructorReturn(this, (LazyLoadDecorated.__proto__ || Object.getPrototypeOf(LazyLoadDecorated)).call(this));
+
+        _this2.displayName = 'LazyLoad' + getDisplayName(WrappedComponent);
+        return _this2;
+      }
+
+      _createClass(LazyLoadDecorated, [{
+        key: 'render',
+        value: function render() {
+          return _react2.default.createElement(
+            LazyLoad,
+            options,
+            _react2.default.createElement(WrappedComponent, this.props)
+          );
+        }
+      }]);
+
+      return LazyLoadDecorated;
+    }(_react.Component);
+  };
+};
+
+exports.lazyload = decorator;
 exports.default = LazyLoad;
 exports.forceCheck = lazyLoadHandler;

--- a/lib/utils/scrollParent.js
+++ b/lib/utils/scrollParent.js
@@ -33,7 +33,7 @@ exports.default = function (node) {
       continue;
     }
 
-    if (overflowRegex.test(overflow) || overflowRegex.test(overflowX) || overflowRegex.test(overflowY)) {
+    if (overflowRegex.test(overflow) && overflowRegex.test(overflowX) && overflowRegex.test(overflowY)) {
       return parent;
     }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -137,7 +137,7 @@ const checkVisible = function checkVisible(component) {
                   checkNormalVisible(component);
   if (visible) {
     // Avoid extra render if previously is visible
-    if (!component.visible) {
+    if (!component.visible && !component.preventLoading) {
       if (component.props.once) {
         pending.push(component);
       }
@@ -186,6 +186,7 @@ class LazyLoad extends Component {
 
     this.visible = false;
     this.setRef = this.setRef.bind(this);
+    this.preventLoading = props.preventLoading;
   }
 
   componentDidMount() {
@@ -250,7 +251,12 @@ class LazyLoad extends Component {
     checkVisible(this);
   }
 
-  shouldComponentUpdate() {
+  shouldComponentUpdate({ preventLoading }) {
+    if (preventLoading !== this.props.preventLoading) {
+      this.preventLoading = preventLoading;
+      checkVisible(this);
+    }
+
     return this.visible;
   }
 
@@ -306,7 +312,8 @@ LazyLoad.propTypes = {
   debounce: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   placeholder: PropTypes.node,
   scrollContainer: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  unmountIfInvisible: PropTypes.bool
+  unmountIfInvisible: PropTypes.bool,
+  preventLoading: PropTypes.bool
 };
 
 LazyLoad.defaultProps = {
@@ -315,7 +322,8 @@ LazyLoad.defaultProps = {
   overflow: false,
   resize: false,
   scroll: true,
-  unmountIfInvisible: false
+  unmountIfInvisible: false,
+  preventLoading: false,
 };
 
 const getDisplayName = WrappedComponent => WrappedComponent.displayName || WrappedComponent.name || 'Component';

--- a/test/specs/lazyload.spec.js
+++ b/test/specs/lazyload.spec.js
@@ -131,6 +131,17 @@ describe('LazyLoad', () => {
 
       expect(document.querySelector('.my-placeholder')).to.exist;
     });
+
+    it('should NOT render if `preventLoading` is set', () => {
+      ReactDOM.render(
+        <div>
+          <LazyLoad height={9999} preventLoading><span className="noboby-can-see-this">123</span></LazyLoad>
+        </div>
+      , div);
+
+      expect(document.querySelector('.noboby-can-see-this')).to.not.exist;
+      expect(document.querySelector('.lazyload-placeholder')).to.exist;
+    });
   });
 
   describe('Checking visibility', () => {


### PR DESCRIPTION
This PR will add a `preventLoading` flag for manual control over the rendering as well as its related tests, examples and usage documentation.
It will allow who uses this library to add custom lazy loading strategies in addition to the standard one, for instance for galleries or any other case which doesn't necessarily rely on scroll to do so.