### PR TITLE
Fixed bug with multiple lazy-loading on 1 screen

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,8 +22,7 @@ try {
     }
   });
   window.addEventListener('test', null, opts);
-}
-catch (e) { }
+} catch (e) { }
 // if they are supported, setup the optional params
 // IMPORTANT: FALSE doubles as the default CAPTURE value!
 const passiveEvent = passiveEventSupported ? { capture: false, passive: true } : false;
@@ -226,16 +225,9 @@ class LazyLoad extends Component {
       }
     }
 
-    if (this.props.overflow) {
-      const parent = scrollParent(this.ref);
-      if (parent && typeof parent.getAttribute === 'function') {
-        const listenerCount = 1 + (+parent.getAttribute(LISTEN_FLAG));
-        if (listenerCount === 1) {
-          parent.addEventListener('scroll', finalLazyLoadHandler, passiveEvent);
-        }
-        parent.setAttribute(LISTEN_FLAG, listenerCount);
-      }
-    } else if (listeners.length === 0 || needResetFinalLazyLoadHandler) {
+    const noOverflow = !this.props.overflow;
+    const noListeners = listeners.length === 0;
+    if (noOverflow && (noListeners || needResetFinalLazyLoadHandler)) {
       const { scroll, resize } = this.props;
 
       if (scroll) {
@@ -244,6 +236,15 @@ class LazyLoad extends Component {
 
       if (resize) {
         on(window, 'resize', finalLazyLoadHandler, passiveEvent);
+      }
+    } else if (this.props.overflow) {
+      const parent = scrollParent(this.ref);
+      if (parent && typeof parent.getAttribute === 'function') {
+        const listenerCount = 1 + (+parent.getAttribute(LISTEN_FLAG));
+        if (listenerCount === 1) {
+          parent.addEventListener('scroll', finalLazyLoadHandler, passiveEvent);
+        }
+        parent.setAttribute(LISTEN_FLAG, listenerCount);
       }
     }
 


### PR DESCRIPTION
## <b>Description</b>

This PR is about solving a bug where the vertical lazy loading stopped working when using a vertical and horizontal lazy load together on one page ([problem video](https://www.youtube.com/watch?v=EteYMMmYEkE)). 

This problem was caused because there was never a scroll listener placed on the window object in this case. This is because both the vertical AND horizontal lazy load containers are using the same "listeners" array. 

So when the first (horizontal) lazy load mounts, it adds listeners to the array and when the time comes that the second (vertical) lazy load mounts, the listeners array > 0 and the scroll listener is never attached.

To solve this problem I;

- Switched the order of the if-else statement and make sure that for non-overflow elements, there's always a scroll listener attached to the window when there are none yet. ([solution video](https://www.youtube.com/watch?v=5aT1TwWzzTc))

## <b>Testing Info</b>

- I've re-run your test and they all seem to pass. I didn't go in-depth into the codebase, but if you see any problems with this merge, be sure to let me know asap.

<img width="801" alt="Screenshot 2019-07-30 at 14 29 17" src="https://user-images.githubusercontent.com/12100448/62129221-7a882900-b2d6-11e9-9cf6-37f8a91a81d9.png">


