### PR TITLE
Adds logic for handling DOM node as scrollContainer

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -198,6 +198,8 @@ class LazyLoad extends Component {
     if (scrollContainer) {
       if (isString(scrollContainer)) {
         scrollport = scrollport.document.querySelector(scrollContainer);
+      } else {
+        scrollport = scrollContainer;
       }
     }
     const needResetFinalLazyLoadHandler = (this.props.debounce !== undefined && delayType === 'throttle')


### PR DESCRIPTION
Based on @opula's fork. The change that seems to make things work is fixing the `scrollContainer` not being set.