### PR TITLE
Utils to force loading of lazy loading components

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ Then call the function:
 forceCheck();
 ```
 
+### forceVisible
+
+Forces the component to display regardless of whether the element is visible in the viewport.
+
+```javascript
+import { forceVisible } from 'react-lazyload';
+```
+
+Then call the function:
+
+```javascript
+forceVisible();
+```
+
 ## Scripts
 
 ```

--- a/examples/app.js
+++ b/examples/app.js
@@ -10,6 +10,7 @@ import Image from './pages/image';
 import Debounce from './pages/debounce';
 import Placeholder from './pages/placeholder';
 import FadeIn from './pages/fadein';
+import ForceVisible from './pages/forcevisible';
 
 const Home = () => (
   <ul className="nav">
@@ -21,6 +22,7 @@ const Home = () => (
     <li><Link to="/debounce">using <code>debounce</code></Link></li>
     <li><Link to="/placeholder">custom placeholder</Link></li>
     <li><Link to="/fadein">cool <code>fadeIn</code> effect</Link></li>
+    <li><Link to="/forcevisible">using forceVisible</Link></li>
   </ul>
 );
 
@@ -35,6 +37,7 @@ const routes = (
     <Route path="/debounce" component={Debounce} />
     <Route path="/placeholder" component={Placeholder} />
     <Route path="/fadein" component={FadeIn} />
+    <Route path="/forcevisible" component={ForceVisible} />
   </Router>
 );
 

--- a/examples/pages/forcevisible.js
+++ b/examples/pages/forcevisible.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+import { forceVisible } from '../../src/';
+import Normal from './normal';
+
+export default class ForceVisible extends Component {
+  componentDidMount() {
+    forceVisible();
+  }
+  render() {
+    return (
+      <Normal />
+    );
+  }
+}
+

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -175,6 +175,19 @@ const lazyLoadHandler = () => {
   purgePending();
 };
 
+/**
+ * Forces the component to display regardless of whether the element is visible in the viewport.
+ */
+const forceVisible = () => {
+  for (let i = 0; i < listeners.length; ++i) {
+    const listener = listeners[i];
+    listener.visible = true;
+    listener.forceUpdate();
+  }
+  // Remove `once` component in listeners
+  purgePending();
+}
+
 // Depending on component's props
 let delayType;
 let finalLazyLoadHandler = null;
@@ -334,3 +347,4 @@ const decorator = (options = {}) => function lazyload(WrappedComponent) {
 export { decorator as lazyload };
 export default LazyLoad;
 export { lazyLoadHandler as forceCheck };
+export { forceVisible };


### PR DESCRIPTION
about https://github.com/twobin/react-lazyload/issues/241

This is the feature to force loading of lazy loading components. 
It can be used when transitioning to a component that is not visible in the page.
I think that you can use it in SSR by hooking componentDidMount.

Forcibly load components that are lazy loaded by writing as follows.

```javascript
import { forceVisible } from 'react-lazyload';

forceVisible();
```