### PR TITLE
Ability to use custom element wrapper type and custom render method

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,40 @@ These being:
 **DEPRECATED NOTICE**
 This props is not supported anymore, try set `overflow` for lazy loading in overflow containers.
 
+### wrapperElementType
+
+Type: String Default: `div`
+
+Element type used as a wrapper. Useful if you cannot use `div` as wrapper (ie. for styling reasons or using different element structure like table) 
+
+### render
+Type: function Default: undefined
+
+When provided it replaces default render method completely so be careful. You should remember to assign `ref` to your element to make library work. 
+
+Example:
+```javascript
+<table>
+    <tbody>
+        <LazyLoad 
+            placeholder={<td>Loading...</td>}
+            render={(props) => (
+                  <tr ref={props.ref}>
+                      {props.visible ? props.children : props.placeholder}
+                  </tr>
+              )}
+          >
+            <td className="test">Test table row</td>
+        </LazyLoad>
+    </tbody>
+</table>
+```
+Props available:
+- all passed to `<LazyLoad` component plus
+  - `visible: boolean` - whether component is visible on screen
+  -  `ref : React ref` - reference to DOM node that wraps `children`
+
+
 ## Utility
 
 ### forceCheck

--- a/examples/app.js
+++ b/examples/app.js
@@ -11,6 +11,8 @@ import Debounce from './pages/debounce';
 import Placeholder from './pages/placeholder';
 import FadeIn from './pages/fadein';
 import ForceVisible from './pages/forcevisible';
+import CustomRender from './pages/customRender'
+import CustomWrapperElementType from './pages/customWrapperElementType';
 
 const Home = () => (
   <ul className="nav">
@@ -23,6 +25,8 @@ const Home = () => (
     <li><Link to="/placeholder">custom placeholder</Link></li>
     <li><Link to="/fadein">cool <code>fadeIn</code> effect</Link></li>
     <li><Link to="/forcevisible">using forceVisible</Link></li>
+    <li><Link to="/customWrapperElementType">using custom wrapper element type</Link></li>
+    <li><Link to="/customRender">using custom render</Link></li>
   </ul>
 );
 
@@ -38,6 +42,8 @@ const routes = (
     <Route path="/placeholder" component={Placeholder} />
     <Route path="/fadein" component={FadeIn} />
     <Route path="/forcevisible" component={ForceVisible} />
+    <Route path="/customWrapperElementType" component={CustomWrapperElementType} />
+    <Route path="/customRender" component={CustomRender} />
   </Router>
 );
 

--- a/examples/pages/customRender.js
+++ b/examples/pages/customRender.js
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import LazyLoad from '../../src/';
+import Operation from '../components/Operation';
+import { uniqueId } from '../utils';
+
+export default class CustomWrapperElementType extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      arr: Array(...Array(20)).map((a, index) => ({
+        uniqueId: uniqueId(),
+        once: [6, 7].indexOf(index) > -1
+      }))
+    };
+  }
+
+  handleClick() {
+    const id = uniqueId();
+
+    this.setState({
+      arr: this.state.arr.map(el => ({
+        ...el,
+        uniqueId: id
+      }))
+    });
+  }
+
+  render() {
+    return (
+      <div className="wrapper">
+        <Operation type="normal" onClickUpdate={::this.handleClick} />
+        <div className="widget-list">
+          <table style={{ border: 'solid 1px black' }}>
+            <thead>
+              <tr><th>Index</th><th>UniqueId</th></tr>
+            </thead>
+            <tbody>
+              {this.state.arr.map((el, index) => (
+                <LazyLoad
+                  once={el.once}
+                  key={index}
+                  height={200}
+                  offset={[-100, 0]}
+                  render={props => (
+                    <tr ref={props.ref} style={{ height: props.height }}>
+                      {props.visible ? props.children : props.placeholder}
+                    </tr>
+                  )}
+                  placeholder={<td>Loading...</td>}
+                >
+                  <td>{index}</td>
+                  <td>{el.uniqueId}</td>
+                </LazyLoad>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}
+

--- a/examples/pages/customWrapperElementType.js
+++ b/examples/pages/customWrapperElementType.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+import LazyLoad from '../../src/';
+import Operation from '../components/Operation';
+import { uniqueId } from '../utils';
+
+export default class CustomWrapperElementType extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      arr: Array(...Array(20)).map((a, index) => ({
+        uniqueId: uniqueId(),
+        once: [6, 7].indexOf(index) > -1
+      }))
+    };
+  }
+
+  handleClick() {
+    const id = uniqueId();
+
+    this.setState({
+      arr: this.state.arr.map(el => ({
+        ...el,
+        uniqueId: id
+      }))
+    });
+  }
+
+  render() {
+    return (
+      <div className="wrapper">
+        <Operation type="normal" onClickUpdate={::this.handleClick} />
+        <div className="widget-list">
+          <table style={{ border: 'solid 1px black' }}>
+            <thead>
+              <tr><th>Index</th><th>UniqueId</th></tr>
+            </thead>
+            <tbody>
+              {this.state.arr.map((el, index) => (
+                <LazyLoad once={el.once} key={index} height={200} offset={[-100, 0]} wrapperElementType={'tr'} placeholder={<td>Loading...</td>}>
+                  <td>{index}</td>
+                  <td>{el.uniqueId}</td>
+                </LazyLoad>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+}
+

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 /**
  * react-lazyload
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { on, off } from './utils/event';
 import scrollParent from './utils/scrollParent';
@@ -115,8 +115,7 @@ const checkNormalVisible = function checkNormalVisible(component) {
   const node = component.ref;
 
   // If this element is hidden by css rules somehow, it's definitely invisible
-  if (!(node.offsetWidth || node.offsetHeight || node.getClientRects().length))
-    return false;
+  if (!(node.offsetWidth || node.offsetHeight || node.getClientRects().length)) { return false; }
 
   let top;
   let elementHeight;
@@ -180,7 +179,7 @@ const checkVisible = function checkVisible(component) {
 };
 
 const purgePending = function purgePending() {
-  pending.forEach(component => {
+  pending.forEach((component) => {
     const index = listeners.indexOf(component);
     if (index !== -1) {
       listeners.splice(index, 1);
@@ -330,25 +329,24 @@ class LazyLoad extends Component {
 
   render() {
     const {
+      render,
       height,
       children,
       placeholder,
-      classNamePrefix
+      classNamePrefix,
+      wrapperElementType,
     } = this.props;
 
-    return (
-      <div className={`${classNamePrefix}-wrapper`} ref={this.setRef}>
-        {this.visible ? (
-          children
-        ) : placeholder ? (
-          placeholder
-        ) : (
-          <div
-            style={{ height: height }}
-            className={`${classNamePrefix}-placeholder`}
-          />
-        )}
-      </div>
+    if (render) {
+      return render({ ...this.props, visible: this.visible, ref: this.setRef });
+    }
+    const defaultPlaceholder = (<div style={{ height }} className={`${classNamePrefix}-placeholder`} />);
+    const content = (<Fragment>{this.visible ? children : placeholder || defaultPlaceholder}</Fragment>);
+
+    return React.createElement(
+      wrapperElementType,
+      { className: `${classNamePrefix}-wrapper`, ref: this.setRef, style: { height: height } },
+      content
     );
   }
 }
@@ -369,7 +367,9 @@ LazyLoad.propTypes = {
   debounce: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   placeholder: PropTypes.node,
   scrollContainer: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  unmountIfInvisible: PropTypes.bool
+  unmountIfInvisible: PropTypes.bool,
+  wrapperElementType: PropTypes.string,
+  render: PropTypes.func,
 };
 
 LazyLoad.defaultProps = {
@@ -379,7 +379,8 @@ LazyLoad.defaultProps = {
   overflow: false,
   resize: false,
   scroll: true,
-  unmountIfInvisible: false
+  unmountIfInvisible: false,
+  wrapperElementType: 'div',
 };
 
 const getDisplayName = WrappedComponent =>

--- a/test/specs/lazyload.spec.js
+++ b/test/specs/lazyload.spec.js
@@ -307,4 +307,28 @@ describe('LazyLoad', () => {
       }
     });
   });
+
+  describe('Changing element type', () => {
+
+      it('should render using table', () => {
+          ReactDOM.render(<table><tbody><LazyLoad wrapperElementType={'tr'}><td className="test">Test table row</td></LazyLoad></tbody></table>, div);
+          expect(document.querySelector('td.test')).to.exist;
+      })
+
+    });
+
+  describe('Using custom render', () => {
+      it('should render using table', () => {
+          ReactDOM.render(<table><tbody><LazyLoad render={(renderProps) => {
+              return (
+                  <tr ref={renderProps.ref}>
+                      {renderProps.visible
+                          ? renderProps.children
+                          : renderProps.placeholder}
+                  </tr>
+              );
+          }}><td className="test">Test table row</td></LazyLoad></tbody></table>, div);
+          expect(document.querySelector('td.test')).to.exist;
+      })
+  });
 });


### PR DESCRIPTION
Add a possibility to use custom element type for wrapper (like `tr` and other - not only `div`). I also added custom property for custom render method for more flexibility. You need to know what you're doing but it provides a lot of options. 
Tests added. 
README updated. 
Examples updated. 

