### PR TITLE
Add scrollContainer fallback

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -233,7 +233,9 @@ class LazyLoad extends Component {
     const { scrollContainer } = this.props;
     if (scrollContainer) {
       if (isString(scrollContainer)) {
-        scrollport = scrollport.document.querySelector(scrollContainer);
+        scrollport = scrollport.document.querySelector(scrollContainer) || window;
+      } else {
+        scrollport = scrollContainer;
       }
     }
     const needResetFinalLazyLoadHandler =


### PR DESCRIPTION
If document.querySelector(scrollContainer) is null, set window to scrollport.
If scrollContainer is DOMNode, set scrollContainer to scrollport.