### PR TITLE
Updated scrollContainer processing logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,10 @@ var _throttle = require('./utils/throttle');
 
 var _throttle2 = _interopRequireDefault(_throttle);
 
+var _isElement = require('./utils/isElement');
+
+var _isElement2 = _interopRequireDefault(_isElement);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -259,7 +263,9 @@ var LazyLoad = function (_Component) {
 
       if (scrollContainer) {
         if (isString(scrollContainer)) {
-          scrollport = scrollport.document.querySelector(scrollContainer);
+          scrollport = scrollport.document.querySelector(scrollContainer) || scrollport;
+        } else if ((0, _isElement2.default)(scrollContainer)) {
+          scrollport = scrollContainer;
         }
       }
       var needResetFinalLazyLoadHandler = this.props.debounce !== undefined && delayType === 'throttle' || delayType === 'debounce' && this.props.debounce === undefined;

--- a/lib/utils/isElement.js
+++ b/lib/utils/isElement.js
@@ -1,0 +1,14 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+/**
+ *  @fileOverview Checks node to be an HTMLElement
+ */
+
+var isElement = function isElement(node) {
+  return node instanceof HTMLElement;
+};
+
+exports.default = isElement;

--- a/lib/utils/scrollParent.js
+++ b/lib/utils/scrollParent.js
@@ -4,12 +4,14 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-/**
- * @fileOverview Find scroll parent
- */
+var _isElement = require('./isElement');
+
+var _isElement2 = _interopRequireDefault(_isElement);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.default = function (node) {
-  if (!(node instanceof HTMLElement)) {
+  if (!(0, _isElement2.default)(node)) {
     return document.documentElement;
   }
 
@@ -41,4 +43,6 @@ exports.default = function (node) {
   }
 
   return node.ownerDocument || node.documentElement || document.documentElement;
-};
+}; /**
+    * @fileOverview Find scroll parent
+    */

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,7 @@ import { on, off } from './utils/event';
 import scrollParent from './utils/scrollParent';
 import debounce from './utils/debounce';
 import throttle from './utils/throttle';
+import isElement from './utils/isElement';
 
 const defaultBoundingClientRect = {
   top: 0,
@@ -233,7 +234,9 @@ class LazyLoad extends Component {
     const { scrollContainer } = this.props;
     if (scrollContainer) {
       if (isString(scrollContainer)) {
-        scrollport = scrollport.document.querySelector(scrollContainer);
+        scrollport = scrollport.document.querySelector(scrollContainer) || scrollport;
+      } else if (isElement(scrollContainer)) {
+        scrollport = scrollContainer;
       }
     }
     const needResetFinalLazyLoadHandler =

--- a/src/utils/isElement.js
+++ b/src/utils/isElement.js
@@ -1,0 +1,7 @@
+/**
+ *  @fileOverview Checks node to be an HTMLElement
+ */
+
+const isElement = node => node instanceof HTMLElement;
+
+export default isElement;

--- a/src/utils/scrollParent.js
+++ b/src/utils/scrollParent.js
@@ -2,8 +2,10 @@
  * @fileOverview Find scroll parent
  */
 
+import isElement from './isElement';
+
 export default (node) => {
-  if (!(node instanceof HTMLElement)) {
+  if (!isElement(node)) {
     return document.documentElement;
   }
 


### PR DESCRIPTION
In this PR the logic to define scrollContainer is proposed.
If scrollContainer is a string it will be used as querySelector, but if none corresponding element is found, it will fall back to window.

If scrollContainer is an instance of an HTMLElement, it will be used as is without any query.

In other cases, when arrays, numbers, null, etc are passed, scrollContainer will stick to its default value [window].