### PR TITLE
Set placeholder width to real component size

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -11,6 +11,7 @@ import Debounce from './pages/debounce';
 import Placeholder from './pages/placeholder';
 import FadeIn from './pages/fadein';
 import ForceVisible from './pages/forcevisible';
+import DynamicHeight from './pages/dynamicheight';
 
 const Home = () => (
   <ul className="nav">
@@ -23,6 +24,7 @@ const Home = () => (
     <li><Link to="/placeholder">custom placeholder</Link></li>
     <li><Link to="/fadein">cool <code>fadeIn</code> effect</Link></li>
     <li><Link to="/forcevisible">using forceVisible</Link></li>
+    <li><Link to="/dynamicheight">with dynamic height elements</Link></li>
   </ul>
 );
 
@@ -38,6 +40,7 @@ const routes = (
     <Route path="/placeholder" component={Placeholder} />
     <Route path="/fadein" component={FadeIn} />
     <Route path="/forcevisible" component={ForceVisible} />
+    <Route path="/dynamicheight" component={DynamicHeight} />
   </Router>
 );
 

--- a/examples/pages/dynamicheight.js
+++ b/examples/pages/dynamicheight.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import Lazyload from '../../src/';
+import Operation from '../components/Operation';
+
+export default class DynamicHeight extends Component {
+  render() {
+    const sizes = [...Array(20).keys()].map(i => (i+1) * 20);
+    return (
+      <div className="wrapper">
+        <Operation type="image" noExtra />
+        <div className="widget-list">
+          {sizes.map(size => 
+            <Lazyload height={100} unmountIfInvisible={true}>
+              <div style={{ height: size, margin: 10, backgroundColor: 'grey' }}>
+                Dynamic element with height {size}
+              </div>
+            </Lazyload>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -152,6 +152,10 @@ const checkVisible = function checkVisible(component) {
     return;
   }
 
+  if(component.visible) {
+    component.visibleHeight = node.clientHeight;
+  }
+
   const parent = scrollParent(node);
   const isOverflow =
     component.props.overflow &&
@@ -223,6 +227,7 @@ class LazyLoad extends Component {
     super(props);
 
     this.visible = false;
+    this.visibleHeight = null;
     this.setRef = this.setRef.bind(this);
   }
 
@@ -346,7 +351,7 @@ class LazyLoad extends Component {
           placeholder
         ) : (
           <div
-            style={{ height: height }}
+            style={{ height: this.visibleHeight || height }}
             className={`${classNamePrefix}-placeholder`}
           />
         )}


### PR DESCRIPTION
Set placeholder width to real component size after render when using unmountIfInvisible. This solves the problem of items jumping around when scrolling. Usefull for when parent component rendering LazyLoad doesn't know the height of the child component. The added example shows the problem when run without the visibleHeight patch and works flawless with it.