### PR TITLE
fix: remove  blank character after className

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-stage-0": "^6.22.0",
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",
+    "classnames": "^2.3.1",
     "eslint": "^4.18.2",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { on, off } from './utils/event';
 import scrollParent from './utils/scrollParent';
 import debounce from './utils/debounce';
@@ -339,7 +340,7 @@ class LazyLoad extends Component {
     } = this.props;
 
     return (
-      <div className={`${classNamePrefix}-wrapper ${className}`} ref={this.setRef} style={style}>
+      <div className={classNames(`${classNamePrefix}-wrapper`, className)} ref={this.setRef} style={style}>
         {this.visible ? (
           children
         ) : placeholder ? (


### PR DESCRIPTION
there are blank characters after className， when there is no className props

![image](https://user-images.githubusercontent.com/18432488/147870756-0996ca55-0bed-4a1c-8c7d-300f69e12024.png)
